### PR TITLE
Add CRUD test coverage for Sidadup tables

### DIFF
--- a/test/sidadup/test_badan_usaha.py
+++ b/test/sidadup/test_badan_usaha.py
@@ -1,0 +1,60 @@
+import pytest
+from httpx import AsyncClient, ASGITransport
+from sqlalchemy import text
+
+from app.main import app
+from app.core.database import SessionLocal, engine
+from app.models.sidadup.badan_usaha import BadanUsaha
+
+NAME = "BADAN-TEST"
+
+
+def _ensure_tables():
+    BadanUsaha.__table__.create(bind=engine, checkfirst=True)
+
+
+def _cleanup():
+    db = SessionLocal()
+    try:
+        db.execute(text("DELETE FROM public.badan_usaha WHERE nama LIKE :n"), {"n": f"{NAME}%"})
+        db.commit()
+    finally:
+        db.close()
+
+
+@pytest.fixture(autouse=True, scope="function")
+def _reset_db():
+    _ensure_tables()
+    _cleanup()
+    yield
+    _cleanup()
+
+
+@pytest.mark.asyncio
+async def test_badan_usaha_crud():
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        resp = await ac.post("/api/badan-usaha", json={"nama": NAME})
+        assert resp.status_code == 201, resp.text
+        badan_id = resp.json()["badan_usaha_id"]
+
+        resp_list = await ac.get("/api/badan-usaha")
+        assert any(r["badan_usaha_id"] == badan_id for r in resp_list.json())
+
+        resp_paged = await ac.get("/api/badan-usaha/paged", params={"search": NAME})
+        assert resp_paged.status_code == 200
+        assert any(r["badan_usaha_id"] == badan_id for r in resp_paged.json()["items"])
+
+        resp_get = await ac.get(f"/api/badan-usaha/{badan_id}")
+        assert resp_get.status_code == 200
+        assert resp_get.json()["nama"] == NAME
+
+        new_name = NAME + "-UPDATED"
+        resp_upd = await ac.put(f"/api/badan-usaha/{badan_id}", json={"nama": new_name})
+        assert resp_upd.status_code == 200
+        assert resp_upd.json()["nama"] == new_name
+
+        resp_del = await ac.delete(f"/api/badan-usaha/{badan_id}")
+        assert resp_del.status_code == 204
+
+        resp_get2 = await ac.get(f"/api/badan-usaha/{badan_id}")
+        assert resp_get2.status_code == 404

--- a/test/sidadup/test_jenis_usaha.py
+++ b/test/sidadup/test_jenis_usaha.py
@@ -1,0 +1,60 @@
+import pytest
+from httpx import AsyncClient, ASGITransport
+from sqlalchemy import text
+
+from app.main import app
+from app.core.database import SessionLocal, engine
+from app.models.sidadup.jenis_usaha import JenisUsaha
+
+NAME = "JENIS-TEST"
+
+
+def _ensure_tables():
+    JenisUsaha.__table__.create(bind=engine, checkfirst=True)
+
+
+def _cleanup():
+    db = SessionLocal()
+    try:
+        db.execute(text("DELETE FROM public.jenis_usaha WHERE nama LIKE :n"), {"n": f"{NAME}%"})
+        db.commit()
+    finally:
+        db.close()
+
+
+@pytest.fixture(autouse=True, scope="function")
+def _reset_db():
+    _ensure_tables()
+    _cleanup()
+    yield
+    _cleanup()
+
+
+@pytest.mark.asyncio
+async def test_jenis_usaha_crud():
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        resp = await ac.post("/api/jenis-usaha", json={"nama": NAME})
+        assert resp.status_code == 201, resp.text
+        jenis_id = resp.json()["jenis_usaha_id"]
+
+        resp_list = await ac.get("/api/jenis-usaha")
+        assert any(r["jenis_usaha_id"] == jenis_id for r in resp_list.json())
+
+        resp_paged = await ac.get("/api/jenis-usaha/paged", params={"search": NAME})
+        assert resp_paged.status_code == 200
+        assert any(r["jenis_usaha_id"] == jenis_id for r in resp_paged.json()["items"])
+
+        resp_get = await ac.get(f"/api/jenis-usaha/{jenis_id}")
+        assert resp_get.status_code == 200
+        assert resp_get.json()["nama"] == NAME
+
+        new_name = NAME + "-UPDATED"
+        resp_upd = await ac.put(f"/api/jenis-usaha/{jenis_id}", json={"nama": new_name})
+        assert resp_upd.status_code == 200
+        assert resp_upd.json()["nama"] == new_name
+
+        resp_del = await ac.delete(f"/api/jenis-usaha/{jenis_id}")
+        assert resp_del.status_code == 204
+
+        resp_get2 = await ac.get(f"/api/jenis-usaha/{jenis_id}")
+        assert resp_get2.status_code == 404

--- a/test/sidadup/test_sektor_perizinan.py
+++ b/test/sidadup/test_sektor_perizinan.py
@@ -1,0 +1,60 @@
+import pytest
+from httpx import AsyncClient, ASGITransport
+from sqlalchemy import text
+
+from app.main import app
+from app.core.database import SessionLocal, engine
+from app.models.sidadup.sektor_perizinan import SektorPerizinan
+
+NAME = "SEKTOR-TEST"
+
+
+def _ensure_tables():
+    SektorPerizinan.__table__.create(bind=engine, checkfirst=True)
+
+
+def _cleanup():
+    db = SessionLocal()
+    try:
+        db.execute(text("DELETE FROM public.sektor_perizinan WHERE nama LIKE :n"), {"n": f"{NAME}%"})
+        db.commit()
+    finally:
+        db.close()
+
+
+@pytest.fixture(autouse=True, scope="function")
+def _reset_db():
+    _ensure_tables()
+    _cleanup()
+    yield
+    _cleanup()
+
+
+@pytest.mark.asyncio
+async def test_sektor_perizinan_crud():
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        resp = await ac.post("/api/sektor-perizinan", json={"nama": NAME})
+        assert resp.status_code == 201, resp.text
+        sektor_id = resp.json()["sektor_id"]
+
+        resp_list = await ac.get("/api/sektor-perizinan")
+        assert any(r["sektor_id"] == sektor_id for r in resp_list.json())
+
+        resp_paged = await ac.get("/api/sektor-perizinan/paged", params={"search": NAME})
+        assert resp_paged.status_code == 200
+        assert any(r["sektor_id"] == sektor_id for r in resp_paged.json()["items"])
+
+        resp_get = await ac.get(f"/api/sektor-perizinan/{sektor_id}")
+        assert resp_get.status_code == 200
+        assert resp_get.json()["nama"] == NAME
+
+        new_name = NAME + "-UPDATED"
+        resp_upd = await ac.put(f"/api/sektor-perizinan/{sektor_id}", json={"nama": new_name})
+        assert resp_upd.status_code == 200
+        assert resp_upd.json()["nama"] == new_name
+
+        resp_del = await ac.delete(f"/api/sektor-perizinan/{sektor_id}")
+        assert resp_del.status_code == 204
+
+        resp_get2 = await ac.get(f"/api/sektor-perizinan/{sektor_id}")
+        assert resp_get2.status_code == 404

--- a/test/sidadup/test_sub_sektor.py
+++ b/test/sidadup/test_sub_sektor.py
@@ -1,0 +1,76 @@
+import pytest
+from httpx import AsyncClient, ASGITransport
+from sqlalchemy import text
+
+from app.main import app
+from app.core.database import SessionLocal, engine
+from app.models.sidadup.sektor_perizinan import SektorPerizinan
+from app.models.sidadup.sub_sektor import SubSektor
+
+SEKTOR_NAME = "SEKTOR-SS-TEST"
+SUB_NAME = "SUBSEKTOR-TEST"
+
+
+def _ensure_tables():
+    SektorPerizinan.__table__.create(bind=engine, checkfirst=True)
+    SubSektor.__table__.create(bind=engine, checkfirst=True)
+
+
+def _cleanup():
+    db = SessionLocal()
+    try:
+        db.execute(text("DELETE FROM public.sub_sektor WHERE nama LIKE :n"), {"n": f"{SUB_NAME}%"})
+        db.execute(text("DELETE FROM public.sektor_perizinan WHERE nama LIKE :n"), {"n": f"{SEKTOR_NAME}%"})
+        db.commit()
+    finally:
+        db.close()
+
+
+@pytest.fixture(autouse=True, scope="function")
+def _reset_db():
+    _ensure_tables()
+    _cleanup()
+    yield
+    _cleanup()
+
+
+@pytest.mark.asyncio
+async def test_sub_sektor_crud():
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        s_resp = await ac.post("/api/sektor-perizinan", json={"nama": SEKTOR_NAME})
+        assert s_resp.status_code == 201, s_resp.text
+        sektor_id = s_resp.json()["sektor_id"]
+
+        resp = await ac.post(
+            "/api/sub-sektor",
+            json={"nama": SUB_NAME, "sektor_id": sektor_id, "custom_column": "CC"},
+        )
+        assert resp.status_code == 201, resp.text
+        sub_id = resp.json()["subsektor_id"]
+
+        resp_list = await ac.get("/api/sub-sektor", params={"sektor_id": sektor_id})
+        assert any(r["subsektor_id"] == sub_id for r in resp_list.json())
+
+        resp_paged = await ac.get(
+            "/api/sub-sektor/paged",
+            params={"sektor_id": sektor_id, "search": SUB_NAME},
+        )
+        assert resp_paged.status_code == 200
+        assert any(r["subsektor_id"] == sub_id for r in resp_paged.json()["items"])
+
+        resp_get = await ac.get(f"/api/sub-sektor/{sub_id}")
+        assert resp_get.status_code == 200
+        assert resp_get.json()["nama"] == SUB_NAME
+
+        new_name = SUB_NAME + "-UPDATED"
+        resp_upd = await ac.put(f"/api/sub-sektor/{sub_id}", json={"nama": new_name})
+        assert resp_upd.status_code == 200
+        assert resp_upd.json()["nama"] == new_name
+
+        resp_del = await ac.delete(f"/api/sub-sektor/{sub_id}")
+        assert resp_del.status_code == 204
+
+        await ac.delete(f"/api/sektor-perizinan/{sektor_id}")
+
+        resp_get2 = await ac.get(f"/api/sub-sektor/{sub_id}")
+        assert resp_get2.status_code == 404


### PR DESCRIPTION
## Summary
- add async CRUD tests for badan_usaha
- add async CRUD tests for jenis_usaha
- add async CRUD tests for sektor_perizinan and sub_sektor

## Testing
- `pytest test/sidadup/test_badan_usaha.py test/sidadup/test_jenis_usaha.py test/sidadup/test_sektor_perizinan.py test/sidadup/test_sub_sektor.py -q` *(fails: OperationalError: connection to server at "127.0.0.1", port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a08382ed9c832da968901309bfc8b8