### PR TITLE
Ensure sub-sektor created_at always populated

### DIFF
--- a/app/models/sidadup/sub_sektor.py
+++ b/app/models/sidadup/sub_sektor.py
@@ -15,6 +15,17 @@ class SubSektor(Base):
     )
     custom_column = Column(Text, nullable=False)
 
-    created_at = Column(DateTime, server_default=func.now(), nullable=False)
+    # Some testing environments may already have an existing ``sub_sektor`` table
+    # without a ``DEFAULT`` value defined for ``created_at``.  When SQLAlchemy
+    # issues an INSERT without specifying this column, Postgres will raise a
+    # ``NOT NULL`` violation.  We keep the server-side default for new tables
+    # but also add a client-side default so SQLAlchemy will explicitly provide
+    # ``NOW()`` during INSERT if the database lacks the default.
+    created_at = Column(
+        DateTime,
+        server_default=func.now(),
+        default=func.now(),
+        nullable=False,
+    )
     updated_at = Column(DateTime, server_default=func.now(), onupdate=func.now(), nullable=True)
     deleted_at = Column(DateTime, nullable=True)


### PR DESCRIPTION
## Summary
- provide client-side default for `SubSektor.created_at` to avoid NOT NULL failures when existing DB lacks default

## Testing
- `pytest test/sidadup/test_sub_sektor.py::test_sub_sektor_crud -q` *(fails: connection to server at "127.0.0.1" refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a08c39f0f4832d89dc8c3795048d61