### PR TITLE
Add data_perizinan table and CRUD API

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -4,8 +4,14 @@ from starlette.middleware.cors import CORSMiddleware
 from app.routers.auth import auth
 from app.routers.desgreen import farea
 from app.routers.tools import shape_to_geojson
-from app.routers.sidadup import kecamatan, jenis_usaha as jenis_usaha_router, badan_usaha as badan_usaha_router, \
-    sub_sektor as subsektor_router, sektor_perizinan as sektor_router
+from app.routers.sidadup import (
+    kecamatan,
+    jenis_usaha as jenis_usaha_router,
+    badan_usaha as badan_usaha_router,
+    sub_sektor as subsektor_router,
+    sektor_perizinan as sektor_router,
+    data_perizinan as data_perizinan_router,
+)
 from app.routers.sidadup import provinsi as provinsi_router
 from app.routers.sidadup import daerah as daerah_router
 
@@ -27,6 +33,7 @@ app.include_router(sektor_router.router)
 app.include_router(subsektor_router.router)
 app.include_router(badan_usaha_router.router)
 app.include_router(jenis_usaha_router.router)
+app.include_router(data_perizinan_router.router)
 @app.get("/")
 async def root():
     return {"message": "Hello World"}

--- a/app/models/sidadup/data_perizinan.py
+++ b/app/models/sidadup/data_perizinan.py
@@ -1,0 +1,47 @@
+from sqlalchemy import BigInteger, Column, String, Date, Text, ForeignKey
+from sqlalchemy.types import UserDefinedType
+from app.core.database import Base
+
+
+class Point(UserDefinedType):
+    def get_col_spec(self, **kw):
+        return "POINT"
+
+
+class DataPerizinan(Base):
+    __tablename__ = "data_perizinan"
+    __table_args__ = {"schema": "public"}
+
+    data_perizinan_id = Column(
+        String,
+        primary_key=True,
+        nullable=False,
+        comment="ymdhis_sektorid_subsektorid",
+    )
+    no_sk = Column(String(100), nullable=False)
+    tanggal_sk = Column(Date, nullable=False)
+    masa_berlaku = Column(Date, nullable=True, comment="tanggal berlaku sampai")
+    custom_data = Column(
+        Text,
+        nullable=False,
+        comment="json value,  key berdasarkan, key di custom_column di subsektor",
+    )
+    subsektor_id = Column(
+        BigInteger,
+        ForeignKey("public.sub_sektor.subsektor_id", onupdate="CASCADE", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    wilayah_id = Column(
+        BigInteger,
+        ForeignKey("public.wilayah.wilayah_id", onupdate="NO ACTION", ondelete="NO ACTION"),
+        nullable=True,
+        index=True,
+    )
+    kecamatan_id = Column(
+        BigInteger,
+        ForeignKey("public.kecamatan.kecamatan_id", onupdate="NO ACTION", ondelete="NO ACTION"),
+        nullable=True,
+        index=True,
+    )
+    latlong = Column(Point, nullable=True)

--- a/app/models/sidadup/wilayah.py
+++ b/app/models/sidadup/wilayah.py
@@ -1,0 +1,9 @@
+from sqlalchemy import BigInteger, Column
+from app.core.database import Base
+
+
+class Wilayah(Base):
+    __tablename__ = "wilayah"
+    __table_args__ = {"schema": "public"}
+
+    wilayah_id = Column(BigInteger, primary_key=True, index=True)

--- a/app/routers/sidadup/data_perizinan.py
+++ b/app/routers/sidadup/data_perizinan.py
@@ -1,0 +1,123 @@
+from typing import List, Optional
+import math
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+
+from app.core.database import get_db
+from app.models.sidadup.data_perizinan import DataPerizinan
+from app.schemas.sidadup.data_perizinan import (
+    DataPerizinanCreate,
+    DataPerizinanUpdate,
+    DataPerizinanRead,
+)
+
+router = APIRouter(prefix="/api/data-perizinan", tags=["data_perizinan"])
+
+
+@router.post("", response_model=DataPerizinanRead, status_code=201)
+def create_data_perizinan(payload: DataPerizinanCreate, db: Session = Depends(get_db)):
+    obj = DataPerizinan(**payload.model_dump(exclude_none=True))
+    db.add(obj)
+    db.commit()
+    db.refresh(obj)
+    return obj
+
+
+@router.get("", response_model=List[DataPerizinanRead])
+def list_data_perizinan(
+    db: Session = Depends(get_db),
+    subsektor_id: Optional[int] = Query(None, description="Filter by subsektor_id"),
+    q: Optional[str] = Query(None, description="Filter by no_sk (ILIKE)"),
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+):
+    query = db.query(DataPerizinan)
+    if subsektor_id is not None:
+        query = query.filter(DataPerizinan.subsektor_id == subsektor_id)
+    if q:
+        query = query.filter(DataPerizinan.no_sk.ilike(f"%{q}%"))
+    return query.order_by(DataPerizinan.data_perizinan_id).offset(offset).limit(limit).all()
+
+
+@router.get("/paged")
+def list_data_perizinan_paged(
+    db: Session = Depends(get_db),
+    subsektor_id: Optional[int] = Query(None, description="Filter by subsektor_id"),
+    search: Optional[str] = Query(None, description="Filter by no_sk (ILIKE)"),
+    q: Optional[str] = Query(None, description="Alias of search (ILIKE)"),
+    pageNo: int = Query(0, ge=0),
+    pageSize: int = Query(50, ge=1, le=200),
+    sortBy: str = Query("id"),
+    order: str = Query("ASC"),
+):
+    term = (search or q or "").strip()
+    allowed_sort = {
+        "id": "data_perizinan_id",
+        "data_perizinan_id": "data_perizinan_id",
+        "no_sk": "no_sk",
+        "tanggal_sk": "tanggal_sk",
+    }
+    sort_prop = allowed_sort.get(sortBy.lower(), "data_perizinan_id")
+    direction_desc = order.lower() == "desc"
+
+    query = db.query(DataPerizinan)
+    if subsektor_id is not None:
+        query = query.filter(DataPerizinan.subsektor_id == subsektor_id)
+    if term:
+        query = query.filter(DataPerizinan.no_sk.ilike(f"%{term}%"))
+
+    total = query.count()
+
+    sort_col = getattr(DataPerizinan, sort_prop)
+    if direction_desc:
+        sort_col = sort_col.desc()
+
+    rows = (
+        query.order_by(sort_col)
+        .offset(pageNo * pageSize)
+        .limit(pageSize)
+        .all()
+    )
+    items = [DataPerizinanRead.model_validate(r).model_dump() for r in rows]
+
+    return {
+        "items": items,
+        "currentPage": pageNo,
+        "pageSize": pageSize,
+        "totalItems": total,
+        "totalPages": math.ceil(total / pageSize) if pageSize else 0,
+    }
+
+
+@router.get("/{data_perizinan_id}", response_model=DataPerizinanRead)
+def get_data_perizinan(data_perizinan_id: str, db: Session = Depends(get_db)):
+    obj = db.get(DataPerizinan, data_perizinan_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="DataPerizinan not found")
+    return obj
+
+
+@router.put("/{data_perizinan_id}", response_model=DataPerizinanRead)
+def update_data_perizinan(
+    data_perizinan_id: str,
+    payload: DataPerizinanUpdate,
+    db: Session = Depends(get_db),
+):
+    obj = db.get(DataPerizinan, data_perizinan_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="DataPerizinan not found")
+    for k, v in payload.model_dump(exclude_none=True).items():
+        setattr(obj, k, v)
+    db.commit()
+    db.refresh(obj)
+    return obj
+
+
+@router.delete("/{data_perizinan_id}", status_code=204)
+def delete_data_perizinan(data_perizinan_id: str, db: Session = Depends(get_db)):
+    obj = db.get(DataPerizinan, data_perizinan_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="DataPerizinan not found")
+    db.delete(obj)
+    db.commit()
+    return {"ok": True}

--- a/app/schemas/sidadup/data_perizinan.py
+++ b/app/schemas/sidadup/data_perizinan.py
@@ -1,0 +1,34 @@
+from datetime import date
+from typing import Optional
+from pydantic import BaseModel, ConfigDict
+
+
+class DataPerizinanBase(BaseModel):
+    data_perizinan_id: str
+    no_sk: str
+    tanggal_sk: date
+    masa_berlaku: Optional[date] = None
+    custom_data: str
+    subsektor_id: int
+    wilayah_id: Optional[int] = None
+    kecamatan_id: Optional[int] = None
+    latlong: Optional[str] = None
+
+
+class DataPerizinanCreate(DataPerizinanBase):
+    pass
+
+
+class DataPerizinanUpdate(BaseModel):
+    no_sk: Optional[str] = None
+    tanggal_sk: Optional[date] = None
+    masa_berlaku: Optional[date] = None
+    custom_data: Optional[str] = None
+    subsektor_id: Optional[int] = None
+    wilayah_id: Optional[int] = None
+    kecamatan_id: Optional[int] = None
+    latlong: Optional[str] = None
+
+
+class DataPerizinanRead(DataPerizinanBase):
+    model_config = ConfigDict(from_attributes=True)

--- a/test/sidadup/test_data_perizinan.py
+++ b/test/sidadup/test_data_perizinan.py
@@ -1,0 +1,98 @@
+import pytest
+from httpx import AsyncClient, ASGITransport
+from sqlalchemy import text
+
+from app.main import app
+from app.core.database import SessionLocal, engine
+from app.models.sidadup.sektor_perizinan import SektorPerizinan
+from app.models.sidadup.sub_sektor import SubSektor
+from app.models.sidadup.provinsi import Provinsi
+from app.models.sidadup.daerah import Daerah
+from app.models.sidadup.kecamatan import Kecamatan
+from app.models.sidadup.wilayah import Wilayah
+from app.models.sidadup.data_perizinan import DataPerizinan
+
+SEKTOR_NAME = "SEK-DP-TEST"
+SUB_NAME = "SUB-DP-TEST"
+DP_ID = "DPTEST-1"
+NO_SK = "NOSK-1"
+
+
+def _ensure_tables():
+    Provinsi.__table__.create(bind=engine, checkfirst=True)
+    Daerah.__table__.create(bind=engine, checkfirst=True)
+    Kecamatan.__table__.create(bind=engine, checkfirst=True)
+    Wilayah.__table__.create(bind=engine, checkfirst=True)
+    SektorPerizinan.__table__.create(bind=engine, checkfirst=True)
+    SubSektor.__table__.create(bind=engine, checkfirst=True)
+    DataPerizinan.__table__.create(bind=engine, checkfirst=True)
+
+
+def _cleanup():
+    db = SessionLocal()
+    try:
+        db.execute(text("DELETE FROM public.data_perizinan WHERE data_perizinan_id = :i"), {"i": DP_ID})
+        db.execute(text("DELETE FROM public.sub_sektor WHERE nama LIKE :n"), {"n": f"{SUB_NAME}%"})
+        db.execute(text("DELETE FROM public.sektor_perizinan WHERE nama LIKE :n"), {"n": f"{SEKTOR_NAME}%"})
+        db.commit()
+    finally:
+        db.close()
+
+
+@pytest.fixture(autouse=True, scope="function")
+def _reset_db():
+    _ensure_tables()
+    _cleanup()
+    yield
+    _cleanup()
+
+
+@pytest.mark.asyncio
+async def test_data_perizinan_crud():
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        s_resp = await ac.post("/api/sektor-perizinan", json={"nama": SEKTOR_NAME})
+        assert s_resp.status_code == 201, s_resp.text
+        sektor_id = s_resp.json()["sektor_id"]
+
+        sub_resp = await ac.post(
+            "/api/sub-sektor",
+            json={"nama": SUB_NAME, "sektor_id": sektor_id, "custom_column": "CC"},
+        )
+        assert sub_resp.status_code == 201, sub_resp.text
+        subsektor_id = sub_resp.json()["subsektor_id"]
+
+        resp = await ac.post(
+            "/api/data-perizinan",
+            json={
+                "data_perizinan_id": DP_ID,
+                "no_sk": NO_SK,
+                "tanggal_sk": "2024-01-01",
+                "masa_berlaku": "2025-01-01",
+                "custom_data": "{}",
+                "subsektor_id": subsektor_id,
+            },
+        )
+        assert resp.status_code == 201, resp.text
+
+        resp_list = await ac.get("/api/data-perizinan")
+        assert any(r["data_perizinan_id"] == DP_ID for r in resp_list.json())
+
+        resp_get = await ac.get(f"/api/data-perizinan/{DP_ID}")
+        assert resp_get.status_code == 200
+        assert resp_get.json()["no_sk"] == NO_SK
+
+        new_no_sk = NO_SK + "-UPD"
+        resp_upd = await ac.put(
+            f"/api/data-perizinan/{DP_ID}", json={"no_sk": new_no_sk}
+        )
+        assert resp_upd.status_code == 200
+        assert resp_upd.json()["no_sk"] == new_no_sk
+
+        resp_del = await ac.delete(f"/api/data-perizinan/{DP_ID}")
+        assert resp_del.status_code == 204
+
+        await ac.delete(f"/api/sub-sektor/{subsektor_id}")
+        await ac.delete(f"/api/sektor-perizinan/{sektor_id}")
+
+        resp_get2 = await ac.get(f"/api/data-perizinan/{DP_ID}")
+        assert resp_get2.status_code == 404


### PR DESCRIPTION
## Summary
- add SQLAlchemy model for `data_perizinan` with FK and column comments
- implement CRUD router and Pydantic schemas
- provide integration tests for `data_perizinan` endpoints
- define minimal `wilayah` model so `data_perizinan` foreign key resolves in tests

## Testing
- `ALGORITHM=HS256 DATABASE_URL='postgresql+psycopg2://desgreen:Welcome1#@127.0.0.1:5432/batukota_perizinan' pytest` *(fails: connection to server at "127.0.0.1", port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a08ffd32e0832da1b270d0c08d8ac2