### PR TITLE
Switch to SQLite-backed tests and enable autoincrement IDs

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -5,9 +5,9 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 class Settings(BaseSettings):
     SECRET_KEY: str = ""
-    ALGORITHM: str = "", #"HS256"
+    ALGORITHM: str = ""  # "HS256"
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 0
-    DATABASE_URL: str = ""
+    DATABASE_URL: str = "sqlite:///./test.db"
 
     # class Config:
     #     env_file = ".env"

--- a/app/core/database.py
+++ b/app/core/database.py
@@ -1,4 +1,4 @@
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, event
 from sqlalchemy.orm import sessionmaker, declarative_base
 from app.core.config import settings
 
@@ -6,15 +6,31 @@ from app.core.config import settings
 # DATABASE_URL = "mysql+pymysql://root:Welcome1#@localhost:3306/des_db"
 DATABASE_URL = settings.DATABASE_URL  # Ambil dari settings
 
+# Untuk SQLite, perlu connect_args agar bisa diakses lintas thread
+connect_args = {"check_same_thread": False} if DATABASE_URL.startswith("sqlite") else {}
+
 engine = create_engine(
     DATABASE_URL,
+    connect_args=connect_args,
     pool_pre_ping=True,   # auto-drop dead connections (portable)
     pool_recycle=3600,    # keep < wait_timeout (MySQL); fine for Postgres too
     future=True,          # SQLAlchemy 2.0 style API
 )
+
+# Mapping schema "public" ke default apabila pakai SQLite
+if DATABASE_URL.startswith("sqlite"):
+    engine = engine.execution_options(schema_translate_map={"public": None})
+
+    db_path = engine.url.database
+
+    @event.listens_for(engine, "connect")
+    def _sqlite_on_connect(dbapi_connection, connection_record):
+        # buat schema alias "public" yang menunjuk ke DB utama
+        dbapi_connection.execute(f"ATTACH DATABASE '{db_path}' AS public")
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 Base = declarative_base()
+
 
 def get_db():
     db = SessionLocal()
@@ -22,6 +38,7 @@ def get_db():
         yield db
     finally:
         db.close()
+
 
 ### Test the database connection: pada Terminal
 # python - << 'PY'

--- a/app/models/sidadup/badan_usaha.py
+++ b/app/models/sidadup/badan_usaha.py
@@ -1,11 +1,11 @@
-from sqlalchemy import BigInteger, Column, String, DateTime, func
+from sqlalchemy import Integer, Column, String, DateTime, func
 from app.core.database import Base
 
 class BadanUsaha(Base):
     __tablename__ = "badan_usaha"
     __table_args__ = {"schema": "public"}
 
-    badan_usaha_id = Column(BigInteger, primary_key=True, index=True, nullable=False)
+    badan_usaha_id = Column(Integer, primary_key=True, index=True, nullable=False, autoincrement=True)
     nama = Column(String(100), nullable=False)
 
     created_at = Column(DateTime, server_default=func.now(), nullable=True)

--- a/app/models/sidadup/daerah.py
+++ b/app/models/sidadup/daerah.py
@@ -1,11 +1,11 @@
-from sqlalchemy import BigInteger, Column, String, ForeignKey, DateTime, func
+from sqlalchemy import BigInteger, Integer, Column, String, ForeignKey, DateTime, func
 from app.core.database import Base
 
 class Daerah(Base):
     __tablename__ = "daerah"
     __table_args__ = {"schema": "public"}
 
-    daerah_id = Column(BigInteger, primary_key=True, index=True)  # DB punya default seq
+    daerah_id = Column(Integer, primary_key=True, index=True, autoincrement=True)
     nama = Column(String(100), nullable=False)
     provinsi_id = Column(
         BigInteger,

--- a/app/models/sidadup/data_perizinan.py
+++ b/app/models/sidadup/data_perizinan.py
@@ -1,4 +1,4 @@
-from sqlalchemy import BigInteger, Column, String, Date, Text, ForeignKey
+from sqlalchemy import BigInteger, Integer, Column, String, Date, Text, ForeignKey
 from sqlalchemy.types import UserDefinedType
 from app.core.database import Base
 
@@ -27,7 +27,7 @@ class DataPerizinan(Base):
         comment="json value,  key berdasarkan, key di custom_column di subsektor",
     )
     subsektor_id = Column(
-        BigInteger,
+        Integer,
         ForeignKey("public.sub_sektor.subsektor_id", onupdate="CASCADE", ondelete="CASCADE"),
         nullable=False,
         index=True,

--- a/app/models/sidadup/jenis_usaha.py
+++ b/app/models/sidadup/jenis_usaha.py
@@ -1,11 +1,11 @@
-from sqlalchemy import BigInteger, Column, String, DateTime, func
+from sqlalchemy import Integer, Column, String, DateTime, func
 from app.core.database import Base
 
 class JenisUsaha(Base):
     __tablename__ = "jenis_usaha"
     __table_args__ = {"schema": "public"}
 
-    jenis_usaha_id = Column(BigInteger, primary_key=True, index=True, nullable=False)
+    jenis_usaha_id = Column(Integer, primary_key=True, index=True, nullable=False, autoincrement=True)
     nama = Column(String(100), nullable=False)
 
     created_at = Column(DateTime, server_default=func.now(), nullable=True)

--- a/app/models/sidadup/kecamatan.py
+++ b/app/models/sidadup/kecamatan.py
@@ -1,14 +1,14 @@
-from sqlalchemy import BigInteger, Column, String, ForeignKey, DateTime, func
+from sqlalchemy import BigInteger, Integer, Column, String, ForeignKey, DateTime, func
 from app.core.database import Base
 
 class Kecamatan(Base):
     __tablename__ = "kecamatan"
     __table_args__ = {"schema": "public"}
 
-    kecamatan_id = Column(BigInteger, primary_key=True, index=True)  # DB punya default seq
+    kecamatan_id = Column(Integer, primary_key=True, index=True, autoincrement=True)
     nama = Column(String(100), nullable=False)
     daerah_id = Column(
-        BigInteger,
+        Integer,
         ForeignKey("public.daerah.daerah_id", onupdate="CASCADE", ondelete="CASCADE"),
         nullable=False,
         index=True,

--- a/app/models/sidadup/sektor_perizinan.py
+++ b/app/models/sidadup/sektor_perizinan.py
@@ -1,11 +1,11 @@
-from sqlalchemy import BigInteger, Column, String, DateTime, func
+from sqlalchemy import Integer, Column, String, DateTime, func
 from app.core.database import Base
 
 class SektorPerizinan(Base):
     __tablename__ = "sektor_perizinan"
     __table_args__ = {"schema": "public"}
 
-    sektor_id = Column(BigInteger, primary_key=True, index=True, nullable=False)
+    sektor_id = Column(Integer, primary_key=True, index=True, nullable=False, autoincrement=True)
     nama = Column(String(100), nullable=False)
 
     created_at = Column(DateTime, server_default=func.now(), nullable=True)

--- a/app/models/sidadup/sub_sektor.py
+++ b/app/models/sidadup/sub_sektor.py
@@ -1,14 +1,14 @@
-from sqlalchemy import BigInteger, Column, String, ForeignKey, Text, DateTime, func
+from sqlalchemy import Integer, Column, String, ForeignKey, Text, DateTime, func
 from app.core.database import Base
 
 class SubSektor(Base):
     __tablename__ = "sub_sektor"
     __table_args__ = {"schema": "public"}
 
-    subsektor_id = Column(BigInteger, primary_key=True, index=True, nullable=False)
+    subsektor_id = Column(Integer, primary_key=True, index=True, nullable=False, autoincrement=True)
     nama = Column(String, nullable=False)
     sektor_id = Column(
-        BigInteger,
+        Integer,
         ForeignKey("public.sektor_perizinan.sektor_id", onupdate="CASCADE", ondelete="CASCADE"),
         nullable=False,
         index=True,

--- a/app/routers/sidadup/kecamatan.py
+++ b/app/routers/sidadup/kecamatan.py
@@ -115,5 +115,5 @@ def delete_kecamatan(kecamatan_id: int, db: Session = Depends(get_db)):
     if not obj:
         raise HTTPException(status_code=404, detail="Kecamatan not found")
     db.delete(obj)
-    db.flush()
+    db.commit()
     return None

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,7 +1,7 @@
 # test/conftest.py
 import os
 import pytest
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, event
 from sqlalchemy.orm import sessionmaker
 from fastapi.testclient import TestClient
 
@@ -13,9 +13,21 @@ from app.core.database import get_db
 # -------------------------------
 TEST_DATABASE_URL = os.getenv(
     "TEST_DATABASE_URL",
-    "postgresql+psycopg2://desgreen:Welcome1#@127.0.0.1:5432/batukota_perizinan",
+    "sqlite:///./test.db",
 )
-engine = create_engine(TEST_DATABASE_URL, future=True)
+
+connect_args = {"check_same_thread": False} if TEST_DATABASE_URL.startswith("sqlite") else {}
+engine = create_engine(TEST_DATABASE_URL, connect_args=connect_args, future=True)
+
+if TEST_DATABASE_URL.startswith("sqlite"):
+    engine = engine.execution_options(schema_translate_map={"public": None})
+
+    db_path = engine.url.database
+
+    @event.listens_for(engine, "connect")
+    def _sqlite_on_connect(dbapi_connection, connection_record):
+        dbapi_connection.execute(f"ATTACH DATABASE '{db_path}' AS public")
+
 TestingSessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False, future=True)
 
 # -------------------------------

--- a/test/sidadup/test_wilayah.py
+++ b/test/sidadup/test_wilayah.py
@@ -37,8 +37,9 @@ def _cleanup():
         db.execute(text("DELETE FROM public.provinsi WHERE provinsi_id = :id2"), {"id2": PROV_ID + 1})
         db.execute(text("DELETE FROM public.provinsi WHERE nama LIKE :pname"), {"pname": "PROV-TEST-E2E%"})
         # reset sequence ke max id + 1
-        db.execute(text("SELECT setval('daerah_daerah_id_seq', COALESCE((SELECT MAX(daerah_id) FROM public.daerah), 0) + 1, false)"))
-        db.execute(text("SELECT setval('kecamatan_kecamatan_id_seq', COALESCE((SELECT MAX(kecamatan_id) FROM public.kecamatan), 0) + 1, false)"))
+        if engine.dialect.name == "postgresql":
+            db.execute(text("SELECT setval('daerah_daerah_id_seq', COALESCE((SELECT MAX(daerah_id) FROM public.daerah), 0) + 1, false)"))
+            db.execute(text("SELECT setval('kecamatan_kecamatan_id_seq', COALESCE((SELECT MAX(kecamatan_id) FROM public.kecamatan), 0) + 1, false)"))
         db.commit()
     finally:
         db.close()


### PR DESCRIPTION
## Summary
- default config/database now use SQLite and map `public` schema for tests
- add autoincrementing integer IDs for sektor/subsektor and other models
- fix kecamatan deletion and adjust tests to avoid Postgres-specific features

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a095f7fe98832db6ed35da6df89684