### PR TITLE
feat: add SQLite compatibility for public schema

### DIFF
--- a/app/models/sidadup/badan_usaha.py
+++ b/app/models/sidadup/badan_usaha.py
@@ -1,9 +1,9 @@
 from sqlalchemy import Integer, Column, String, DateTime, func
-from app.core.database import Base
+from app.core.database import Base, PUBLIC_SCHEMA
 
 class BadanUsaha(Base):
     __tablename__ = "badan_usaha"
-    __table_args__ = {"schema": "public"}
+    __table_args__ = {"schema": PUBLIC_SCHEMA}
 
     badan_usaha_id = Column(Integer, primary_key=True, index=True, nullable=False, autoincrement=True)
     nama = Column(String(100), nullable=False)

--- a/app/models/sidadup/daerah.py
+++ b/app/models/sidadup/daerah.py
@@ -1,15 +1,18 @@
 from sqlalchemy import BigInteger, Integer, Column, String, ForeignKey, DateTime, func
-from app.core.database import Base
+from app.core.database import Base, PUBLIC_SCHEMA
+
+SCHEMA_PREFIX = f"{PUBLIC_SCHEMA}." if PUBLIC_SCHEMA else ""
+
 
 class Daerah(Base):
     __tablename__ = "daerah"
-    __table_args__ = {"schema": "public"}
+    __table_args__ = {"schema": PUBLIC_SCHEMA}
 
     daerah_id = Column(Integer, primary_key=True, index=True, autoincrement=True)
     nama = Column(String(100), nullable=False)
     provinsi_id = Column(
         BigInteger,
-        ForeignKey("public.provinsi.provinsi_id", onupdate="CASCADE", ondelete="CASCADE"),
+        ForeignKey(f"{SCHEMA_PREFIX}provinsi.provinsi_id", onupdate="CASCADE", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )

--- a/app/models/sidadup/data_perizinan.py
+++ b/app/models/sidadup/data_perizinan.py
@@ -1,6 +1,6 @@
 from sqlalchemy import BigInteger, Integer, Column, String, Date, Text, ForeignKey
 from sqlalchemy.types import UserDefinedType
-from app.core.database import Base
+from app.core.database import Base, PUBLIC_SCHEMA
 
 
 class Point(UserDefinedType):
@@ -8,9 +8,12 @@ class Point(UserDefinedType):
         return "POINT"
 
 
+SCHEMA_PREFIX = f"{PUBLIC_SCHEMA}." if PUBLIC_SCHEMA else ""
+
+
 class DataPerizinan(Base):
     __tablename__ = "data_perizinan"
-    __table_args__ = {"schema": "public"}
+    __table_args__ = {"schema": PUBLIC_SCHEMA}
 
     data_perizinan_id = Column(
         String,
@@ -28,19 +31,19 @@ class DataPerizinan(Base):
     )
     subsektor_id = Column(
         Integer,
-        ForeignKey("public.sub_sektor.subsektor_id", onupdate="CASCADE", ondelete="CASCADE"),
+        ForeignKey(f"{SCHEMA_PREFIX}sub_sektor.subsektor_id", onupdate="CASCADE", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )
     wilayah_id = Column(
         BigInteger,
-        ForeignKey("public.wilayah.wilayah_id", onupdate="NO ACTION", ondelete="NO ACTION"),
+        ForeignKey(f"{SCHEMA_PREFIX}wilayah.wilayah_id", onupdate="NO ACTION", ondelete="NO ACTION"),
         nullable=True,
         index=True,
     )
     kecamatan_id = Column(
         BigInteger,
-        ForeignKey("public.kecamatan.kecamatan_id", onupdate="NO ACTION", ondelete="NO ACTION"),
+        ForeignKey(f"{SCHEMA_PREFIX}kecamatan.kecamatan_id", onupdate="NO ACTION", ondelete="NO ACTION"),
         nullable=True,
         index=True,
     )

--- a/app/models/sidadup/jenis_usaha.py
+++ b/app/models/sidadup/jenis_usaha.py
@@ -1,9 +1,9 @@
 from sqlalchemy import Integer, Column, String, DateTime, func
-from app.core.database import Base
+from app.core.database import Base, PUBLIC_SCHEMA
 
 class JenisUsaha(Base):
     __tablename__ = "jenis_usaha"
-    __table_args__ = {"schema": "public"}
+    __table_args__ = {"schema": PUBLIC_SCHEMA}
 
     jenis_usaha_id = Column(Integer, primary_key=True, index=True, nullable=False, autoincrement=True)
     nama = Column(String(100), nullable=False)

--- a/app/models/sidadup/kecamatan.py
+++ b/app/models/sidadup/kecamatan.py
@@ -1,15 +1,18 @@
 from sqlalchemy import BigInteger, Integer, Column, String, ForeignKey, DateTime, func
-from app.core.database import Base
+from app.core.database import Base, PUBLIC_SCHEMA
+
+SCHEMA_PREFIX = f"{PUBLIC_SCHEMA}." if PUBLIC_SCHEMA else ""
+
 
 class Kecamatan(Base):
     __tablename__ = "kecamatan"
-    __table_args__ = {"schema": "public"}
+    __table_args__ = {"schema": PUBLIC_SCHEMA}
 
     kecamatan_id = Column(Integer, primary_key=True, index=True, autoincrement=True)
     nama = Column(String(100), nullable=False)
     daerah_id = Column(
         Integer,
-        ForeignKey("public.daerah.daerah_id", onupdate="CASCADE", ondelete="CASCADE"),
+        ForeignKey(f"{SCHEMA_PREFIX}daerah.daerah_id", onupdate="CASCADE", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )

--- a/app/models/sidadup/provinsi.py
+++ b/app/models/sidadup/provinsi.py
@@ -1,9 +1,9 @@
 from sqlalchemy import BigInteger, Column, String, DateTime, func
-from app.core.database import Base
+from app.core.database import Base, PUBLIC_SCHEMA
 
 class Provinsi(Base):
     __tablename__ = "provinsi"
-    __table_args__ = {"schema": "public"}
+    __table_args__ = {"schema": PUBLIC_SCHEMA}
 
     provinsi_id = Column(BigInteger, primary_key=True, index=True, nullable=False)
     nama = Column(String(100), nullable=False)

--- a/app/models/sidadup/sektor_perizinan.py
+++ b/app/models/sidadup/sektor_perizinan.py
@@ -1,9 +1,9 @@
 from sqlalchemy import Integer, Column, String, DateTime, func
-from app.core.database import Base
+from app.core.database import Base, PUBLIC_SCHEMA
 
 class SektorPerizinan(Base):
     __tablename__ = "sektor_perizinan"
-    __table_args__ = {"schema": "public"}
+    __table_args__ = {"schema": PUBLIC_SCHEMA}
 
     sektor_id = Column(Integer, primary_key=True, index=True, nullable=False, autoincrement=True)
     nama = Column(String(100), nullable=False)

--- a/app/models/sidadup/sub_sektor.py
+++ b/app/models/sidadup/sub_sektor.py
@@ -1,15 +1,18 @@
 from sqlalchemy import Integer, Column, String, ForeignKey, Text, DateTime, func
-from app.core.database import Base
+from app.core.database import Base, PUBLIC_SCHEMA
+
+SCHEMA_PREFIX = f"{PUBLIC_SCHEMA}." if PUBLIC_SCHEMA else ""
+
 
 class SubSektor(Base):
     __tablename__ = "sub_sektor"
-    __table_args__ = {"schema": "public"}
+    __table_args__ = {"schema": PUBLIC_SCHEMA}
 
     subsektor_id = Column(Integer, primary_key=True, index=True, nullable=False, autoincrement=True)
     nama = Column(String, nullable=False)
     sektor_id = Column(
         Integer,
-        ForeignKey("public.sektor_perizinan.sektor_id", onupdate="CASCADE", ondelete="CASCADE"),
+        ForeignKey(f"{SCHEMA_PREFIX}sektor_perizinan.sektor_id", onupdate="CASCADE", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )

--- a/app/models/sidadup/wilayah.py
+++ b/app/models/sidadup/wilayah.py
@@ -1,9 +1,9 @@
 from sqlalchemy import BigInteger, Column
-from app.core.database import Base
+from app.core.database import Base, PUBLIC_SCHEMA
 
 
 class Wilayah(Base):
     __tablename__ = "wilayah"
-    __table_args__ = {"schema": "public"}
+    __table_args__ = {"schema": PUBLIC_SCHEMA}
 
     wilayah_id = Column(BigInteger, primary_key=True, index=True)

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -1,0 +1,27 @@
+import sqlalchemy
+from sqlalchemy import create_engine as _sa_create_engine
+from sqlalchemy.event import listen
+
+
+def _patched_create_engine(*args, **kwargs):
+    """Wrapper around SQLAlchemy's ``create_engine``.
+
+    For SQLite connections we automatically attach a ``public`` schema alias so
+    that SQL statements referencing ``public.<table>`` work just like in
+    PostgreSQL.  This mimics the behaviour implemented in ``app.core.database``
+    and keeps the test suite agnostic of the actual database backend.
+    """
+    engine = _sa_create_engine(*args, **kwargs)
+    if engine.url.get_backend_name().startswith("sqlite"):
+        # Apply schema translation so "public" maps to the default schema
+        engine.update_execution_options(schema_translate_map={"public": None})
+        db_path = engine.url.database
+
+        def _on_connect(dbapi_connection, connection_record):
+            dbapi_connection.execute(f"ATTACH DATABASE '{db_path}' AS public")
+
+        listen(engine, "connect", _on_connect)
+    return engine
+
+# Override SQLAlchemy's factory with the patched version
+sqlalchemy.create_engine = _patched_create_engine


### PR DESCRIPTION
## Summary
- add schema-agnostic engine and global patch so SQLite understands the `public` schema
- wire models to use configurable schema constant
- ensure tests can auto-create required tables

## Testing
- `TEST_DATABASE_URL=sqlite:///./test.db pytest test/sidadup/test_data_perizinan.py::test_data_perizinan_crud -q` *(fails: `no such table: public.sektor_perizinan`)*

------
https://chatgpt.com/codex/tasks/task_e_68a09e88ee14832d88cd0316dfb713fb